### PR TITLE
fix download_data until rap_copy_from is ready

### DIFF
--- a/R/import-data.R
+++ b/R/import-data.R
@@ -25,10 +25,11 @@ download_data <- function(project_id = get_rap_project_id(),
     with = "rap_copy_from()"
   )
   file_ext <- rlang::arg_match(file_ext)
-  rap_path <- rap_get_path_user_files(rap_get_user()) |>
+  rap_file <- rap_get_path_user_files(rap_get_user()) |>
     stringr::str_subset(file_ext) |>
     stringr::str_sort(decreasing = TRUE) |>
     head(1)
+  rap_path <- glue::glue("/users/{username}/{rap_file}")
 
   cli::cli_alert_info("Downloading from RAP: {.val {rap_path}}.")
   output_path <- glue::glue("data/data.{file_ext}")


### PR DESCRIPTION
Looks promising with the updated updated `rap-variables`! I had some issues with `rap_copy_from`; I found a way to solve it, but I'm not confident enough to create a pull request on that. The solve does work on `download_data` as well, so I've added it here. I still had to add my username to the csv-file manually as it for some reason disappears when I create a new dataset (I will open an issue on that). It looks like it's almost working!